### PR TITLE
Disable mobile double tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>テトリス登りゲーム</title>
     <style>
         * {
@@ -19,6 +19,7 @@
             align-items: center;
             justify-content: center;
             padding: 10px;
+            touch-action: manipulation;
         }
 
         .game-container {
@@ -289,6 +290,16 @@
     </div>
 
     <script>
+        // Prevent double-tap zoom on mobile devices
+        let lastTouchEnd = 0;
+        document.addEventListener('touchend', function(event) {
+            const now = Date.now();
+            if (now - lastTouchEnd <= 300) {
+                event.preventDefault();
+            }
+            lastTouchEnd = now;
+        }, false);
+
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas.getContext('2d');
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,13 @@
+// Prevent double-tap zoom on mobile devices
+let lastTouchEnd = 0;
+document.addEventListener('touchend', function(event) {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 300) {
+        event.preventDefault();
+    }
+    lastTouchEnd = now;
+}, false);
+
 // ゲームの基本設定
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@ body {
     align-items: center;
     justify-content: center;
     padding: 10px;
+    touch-action: manipulation;
 }
 
 .game-container {


### PR DESCRIPTION
## Summary
- prevent mobile zoom by blocking double-tap gestures
- disallow user scaling via viewport meta tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b836fd49e48330bb6fedebf803412b