### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,8 @@
             gap: 20px;
             margin-top: 20px;
             z-index: 10;
+            flex-wrap: wrap;
+            justify-content: center;
         }
 
         .control-btn {
@@ -263,6 +265,48 @@
         @keyframes glow {
             from { text-shadow: 0 0 15px #00ffff; }
             to { text-shadow: 0 0 25px #00ffff, 0 0 35px #00ffff; }
+        }
+
+        /* Responsive layout adjustments for small screens */
+        @media (max-width: 640px) {
+            body {
+                height: auto;
+                padding: 10px;
+            }
+
+            .game-container {
+                height: auto;
+                max-height: none;
+                padding: 10px;
+            }
+
+            .info-panel {
+                flex-direction: column;
+                gap: 10px;
+                font-size: 1.25rem;
+                text-align: center;
+            }
+
+            .stage {
+                height: 300px;
+            }
+
+            .controls {
+                width: 100%;
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .control-btn {
+                width: 100%;
+                padding: 12px;
+                font-size: 1rem;
+            }
+
+            .character-svg {
+                width: 100px;
+                height: 100px;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- Allow control buttons to wrap and center for small screens
- Add responsive styles for better mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad1081bfc83308fe86cf7647ec56f